### PR TITLE
Add a short post with links to upcoming webinars.

### DIFF
--- a/content/blogs.md
+++ b/content/blogs.md
@@ -5,6 +5,18 @@ type: page
 include_footer: true
 ---
 
+## Upcoming OpenSSF and CNCF webinars
+
+#### GUAC Community
+
+##### May 17, 2024
+
+Join us for two upcoming webinars to learn more about GUAC.
+
+* [OpenSSF Tech Talk](https://openssf.org/blog/2024/05/16/join-our-upcoming-openssf-tech-talk-proactive-supply-chain-security-with-guac/) — 6 Jun at 1 PM Eastern (1700 UTC)
+* [CNCF Live](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cloud-native-live-guac-101-dip-into-the-delicious-world-of-software-supply-chain-security/) — 11 Jun at noon Eastern (1600 UTC)
+
+---
 
 <h2><a href="https://www.kusari.dev/blog/graph-for-understanding-artifact-composition-guac-adds-persistent-storage-in-v0-6-0-release">Graph for Understanding Artifact Composition (GUAC) adds persistent storage in v0.6.0 release</a></h2>
 


### PR DESCRIPTION
It's a short post, but it spreads the word a bit. Given the fact that historical blog posts are short links to other posts, I didn't want to get too lengthy with this one. (We may want to revisit that later, but for now it's fine)