### PR TITLE
Change the "try it out" button to point to the getting started demo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ params:
     button1text: Find out more
     button1link: "#problem"
     button2text: Try it out
-    button2link: "https://docs.guac.sh"
+    button2link: "https://docs.guac.sh/getting-started/"
     button3text: Now an OpenSSF incubating project!
     button3link: "https://openssf.org/blog/2024/03/07/guac-joins-openssf-as-incubating-project/"
 


### PR DESCRIPTION
This seems like a better place to send people than the main docs page.