### PR TITLE
Add RSS feed for blog

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,10 +5,19 @@ canonifyURLs: true
 title: guac
 theme: hugo-fresh
 googleAnalytics: G-VVPLWNX4L9
+outputs:
+  home:
+    - html
+  section:
+    - html
+    - rss
 # Disables warnings
 disableKinds:
 - taxonomy
 - taxonomyTerm
+services:
+  rss:
+    limit: 10
 markup:
   goldmark:
     renderer:
@@ -242,21 +251,16 @@ params:
     # Logo (from /images/logos/___)
     logo: guac-logo-squareish.png
     # Social Media Title
-    # socialmediatitle: Follow Us
+    socialmediatitle: Follow GUAC
     # # Social media links (GitHub, Twitter, etc.). All are optional.
-    # socialmedia:
-    # - link: https://github.com/lucperkins/github-fresh
+    socialmedia:
     #   # Icons are from Font Awesome
-    #   icon: github
-    # - link: https://dribbble.com/#
-    #   icon: dribbble
-    # - link: https://facebook.com/#
-    #   icon: facebook
-    # - link: https://twitter.com/lucperkins
-    #   icon: twitter
-    # - link: https://bitbucket.org/#
-    #   icon: bitbucket
-    # bulmalogo: true
+      - link: /blog/index.xml
+        icon: rss
+      - link: https://youtube.com/@guacsec
+        icon: youtube
+      - link: https://github.com/guacsec
+        icon: github
     quicklinks:
       column1:
         title: "Community"
@@ -270,6 +274,3 @@ params:
       column4:
         title: "Docs"
         titleLink: https://docs.guac.sh/
-      column5:
-        title: "Github"
-        titleLink: https://github.com/guacsec/guac

--- a/themes/hugo-fresh/layouts/_default/section.html
+++ b/themes/hugo-fresh/layouts/_default/section.html
@@ -4,6 +4,9 @@
     {{ partial "meta.html" . }}
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     {{ partial "css.html" . }}
+    {{ with .OutputFormats.Get "rss" -}}
+      {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+    {{ end }}
   </head>
   <body>
     <!-- Preloader -->

--- a/themes/hugo-fresh/layouts/partials/footer.html
+++ b/themes/hugo-fresh/layouts/partials/footer.html
@@ -32,7 +32,7 @@
           </div>
         </div>
       {{- end }}
-      <!-- <div class="column">
+      <div class="column">
         <div class="footer-column">
           <div class="footer-header">
             <h3>{{ $socialMediaTitle }}</h3>
@@ -53,7 +53,7 @@
             {{- end }}
           </div>
         </div>
-      </div> -->
+      </div>
     </div>
     <span class="copy">Copyright &copy; {{ .Site.Params.mysite.copystart }} - {{ dateFormat "2006" now }} GUAC a Series of LF Projects, LLC. For web site terms of use, trademark policy and other project policies please see https://lfprojects.org/</span>
   </div>

--- a/themes/hugo-fresh/layouts/partials/section/content.html
+++ b/themes/hugo-fresh/layouts/partials/section/content.html
@@ -2,7 +2,10 @@
   <div class="container">
     <div class="columns">
       <div class="column is-centered-tablet-portrait">
-        <h1 class="title section-title">{{ .Title }}</h1>
+        <h1 class="title section-title">{{ .Title }}
+        {{ with .OutputFormats.Get "rss" -}}
+        <span class="icon"><a href="{{ .Permalink }}"><i class="fa fa-rss"></i></span></a></h1>
+        {{ end }}
         <div class="divider"></div>
           <div class="content">
             {{ range .Pages }}


### PR DESCRIPTION
The feed was apparently already being generated, so I just made it visible (and suppressed creating a feed for the home page because it doesn't make sense how we're using it.)

As part of making it visible, I added social media links to the footer. We have the RSS and YouTube links to add and for the purposes of improving spacing, I moved GitHub from the text links to be a social icon link. The footer links are largely duplicating the header links anyway, so it doesn't feel like a real loss in usability.

Fixes #36