### PR TITLE
Update the mailing list location

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -47,9 +47,10 @@ to the meetings at the following links:
 - [EMEA Office Hours](https://zoom-lfx.platform.linuxfoundation.org/meeting/98129525584?password=db7b7e22-e1eb-4936-962c-2840475ab11c)
 - [NA Office Hours](https://zoom-lfx.platform.linuxfoundation.org/meeting/99570351921?password=6537e2c3-4631-4d5f-9632-3156c9b2f5cb)
 
-### Groups / Mailing lists
+### Mailing list
 
-[Public mailing list/GUAC community google group](https://groups.google.com/forum/#!forum/guac-community/join) for future updates, announcements, and community meetings.
+Join the [GUAC list on OpenSSF](https://lists.openssf.org/g/GUAC) for announcements and discussion.
+Everyone is welcome to post.
 
 ### Governance
 


### PR DESCRIPTION
Move from a Google Group to OpenSSF's mail server as discussed in guacsec/governance#6