### PR TITLE
Improve messaging/positioning of GUAC

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ params:
     subtitle: GUAC gives you directed, actionable insights into the security of your software supply chain.
     # Button text
     button1text: Find out more
-    button1link: "#problem"
+    button1link: "/why-guac"
     button2text: Try it out
     button2link: "https://docs.guac.sh/getting-started/"
     button3text: Now an OpenSSF incubating project!
@@ -63,6 +63,8 @@ params:
     # - gutwork
   # Customizable navbar. For a dropdown, add a "sublinks" list.
   navbar:
+  - title: Why GUAC?
+    url: /why-guac
   - title: Community
     url: /community
   - title: Blogs
@@ -200,10 +202,6 @@ params:
     button1Link: https://github.com/guacsec/guac
     button2Text: Demos
     button2Link: https://docs.guac.sh/guac-use-cases/
-
-  sectionProblem:
-    title: The current problem with software supply chain security
-    subtitle: Software supply chain attacks are on the rise and it’s hard to know what your software is at risk for and how to protect it. Many tools are available to help you generate Software Bills of Materials (SBOMs), signed attestations, and vulnerability reports, but they stop there, leaving you to figure out how they all fit together.
 
   sectionVision:
     title: Our Vision

--- a/content/why-guac.md
+++ b/content/why-guac.md
@@ -1,0 +1,57 @@
+---
+title: "Why GUAC?"
+section: single
+type: page
+include_footer: true
+---
+
+## The current problem with software supply chain security
+
+Software supply chain attacks are on the rise and it’s hard to know what your software is at risk for and how to protect it.
+Many tools are available to help you generate software bills of materials (SBOMs), signed attestations, and vulnerability reports, but they stop there, leaving you to figure out how they all fit together.
+GUAC provides an aggregated, queryable view across your whole software supply chain, not just one SBOM at a time.
+
+## From data to knowledge
+
+Consider the [DIKW pyramid](https://en.wikipedia.org/wiki/DIKW_pyramid).
+You have *data* about your software supply chain in the form of SBOMs, vulnerability statements, and the like.
+GUAC builds a graph of the relationships between the data in order to provide *information*.
+With GUAC, you can ask questions of your supply chain relationships to get *knowledge*.
+By ingesting local information and trusted third-party sources, GUAC gives you the ability to perform a comprehensive analysis.
+
+## Use cases
+
+GUAC is for developers, operations, and security practitioners who need to identify and address problems in their software supply chain, including proactively managing dependencies and responding to vulnerabilities.
+GUAC provides supply chain observability with a graph view of the software supply chain and tools for performing queries to gain actionable insights.
+
+Here are some common use cases for GUAC.
+[Let us know](/community) yours.
+
+### Developers
+
+* Identify deprecated and unsupported dependencies
+* Discover “version sprawl”, where several versions of the same dependency are included
+* Locate and remediate vulnerable dependencies
+* Identify risky upstreams based on security practices evaluated by OpenSSF Scorecard
+
+### Operations engineers
+
+* Locate and remediate vulnerable dependencies
+
+### Security engineers
+
+* Locate and remediate vulnerable dependencies
+* Prevent known vulnerable packages and sources from being used in applications
+
+### Open Source Program Offices
+
+* Identify strategically important open source upstreams
+* Identify open source upstreams that could benefit from security help based on OpenSSF Scorecard results
+
+## Differentiation
+
+GUAC has three key differentiating features from other tools in this space
+
+* **Works on more than one SBOM at a time.** This allows observability into the entire software portfolio instead of application-by-application.
+* **Aggregates additional data beyond the SBOM.** GUAC brings in data like dependencies and vulnerabilities from trusted third-party sources, enriching the supply chain graph.
+* **Provides APIs and a visualization tool.** GUAC’s query and visualization tooling let the user get the answers to the questions they need to ask.

--- a/themes/hugo-fresh/layouts/partials/section1.html
+++ b/themes/hugo-fresh/layouts/partials/section1.html
@@ -2,7 +2,7 @@
 {{- $title    := index $section1 "title" }}
 {{- $subtitle := index $section1 "subtitle" }}
 {{- $tiles    := index $section1 "tiles" }}
-<section class="section section-secondary is-medium">
+<section class="section section-quad is-medium">
   <div class="container">
     <div class="title-wrapper has-text-centered">
       <h2 class="title is-2 light-text">{{ $title }}</h2>


### PR DESCRIPTION
Create a dedicated "why GUAC?" page that covers the problems that GUAC solves and lists some persona-specific use cases. (Eventually, it would be good to have an example for each of those in the docs).

Moves the "problem" section content to that page, too.

Fixes #22