### PR TITLE
Make `include_footer` default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This is the date used by Hugo to sort the posts.
 *If you use a date in the future, it will not be listed on the blog page.*
 * `authors` (optional): An array of names to list as the author.
 If you only have one author, it still needs to be quoted and in square brackets.
-* `include_footer`: Something we shouldn't have to add, but do for now.
 
 A complete header looks something like:
 
@@ -41,7 +40,6 @@ A complete header looks something like:
 title: This is a great blog post
 date: 2023-04-13
 authors: ["Ben Cotton", "Jane Doe", "Blogger McBlogface"]
-include_footer: true
 ---
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ markup:
       unsafe: true # Allows you to write raw html in your md files
 
 params:
+  include_footer: true
   # Open graph allows easy social sharing. If you don't want it you can set it to false or just delete the variable
   openGraph: true
   # Used as meta data; describe your site to make Google Bots happy

--- a/content/community.md
+++ b/content/community.md
@@ -2,7 +2,6 @@
 title: "Community"
 section: single
 type: page
-include_footer: true
 ---
 
 Welcome to the GUAC community!

--- a/content/contributing.md
+++ b/content/contributing.md
@@ -2,7 +2,6 @@
 title: "Contributing to GUAC"
 section: single
 type: page
-include_footer: true
 ---
 
 Interested in making a contribution to GUAC?

--- a/content/why-guac.md
+++ b/content/why-guac.md
@@ -2,7 +2,6 @@
 title: "Why GUAC?"
 section: single
 type: page
-include_footer: true
 ---
 
 ## The current problem with software supply chain security

--- a/themes/hugo-fresh/layouts/_default/single.html
+++ b/themes/hugo-fresh/layouts/_default/single.html
@@ -15,7 +15,8 @@
 
     {{ partial "single/single.html" . }}
 
-    {{ if .Params.include_footer }}
+    {{ $include_footer := .Params.include_footer | default .Site.Params.include_footer }}
+    {{ if $include_footer }}
     {{ partial "footer.html" . }}
     {{ end }}
 


### PR DESCRIPTION
We set this on each page, so it might as well be the default. If there are specific pages we don't want the footer on, it can bet set to false on that page's frontmatter.

I removed the explicit setting from the main content pages to make it clear that they follow the default. I did not remove it from the blog entries because they will not likely be edited again (although I'm open to argument that we should remove it there for consistency and in case we decide to change the site default in the future.)

Fixes #51