### PR TITLE
Update build workflow to latest Hugo (v0.133.0)

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.111.3
+      HUGO_VERSION: 0.133.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/themes/hugo-fresh/layouts/partials/css.html
+++ b/themes/hugo-fresh/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := .Site.IsServer }}
+{{- $inServerMode := hugo.IsServer }}
 {{- $sass         := "style.sass" }}
 {{- $cssTarget    := "css/style.css" }}
 {{- $cssOpts      := cond ($inServerMode) (dict "targetPath" $cssTarget "enableSourceMap" true) (dict "targetPath" $cssTarget "outputStyle" "compressed") }}

--- a/themes/hugo-fresh/layouts/partials/ganalytics.html
+++ b/themes/hugo-fresh/layouts/partials/ganalytics.html
@@ -1,4 +1,4 @@
-{{- $gcode := .Site.GoogleAnalytics }}
+{{- $gcode := .Site.Config.Services.GoogleAnalytics.ID }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ $gcode }}"></script>
 <script>


### PR DESCRIPTION
The [1k+ commits](https://github.com/gohugoio/hugo/compare/v0.111.3...v0.133.0) between our current (0.111.3) and the latest (0.133.0) release include several security fixes, both in Hugo and in the Go compiler used to build the artifacts.

In addition to updating the version in the workflow, this commit addresses two configuration settings that were deprecated in v0.120.0 and now produce errors.

* [`GoogleAnalytics`](https://github.com/gohugoio/hugo/commit/a692278bc679af44f69cc49c11efc412edd979a0)
* [`IsServer`](https://github.com/gohugoio/hugo/issues/11510)

Local builds using 0.133.0 produce the site as expected, including embedding the GoogleAnalytics code.